### PR TITLE
Improve mobile layout

### DIFF
--- a/index_de.html
+++ b/index_de.html
@@ -139,9 +139,12 @@
         width: 100vw;
         max-width: 100vw;
         box-sizing: border-box;
-        padding: 10px 0 10px -10;
+        padding: 10px;
         border-radius: 0;
         box-shadow: none;
+      }
+      .form-group label {
+        flex: 0 0 100%;
       }
       #outputBox {
         min-width: 0;
@@ -253,10 +256,17 @@ function adjustFontSize() {
   }
 
   textElem.style.fontFamily = fontStack;
-  textElem.style.fontWeight = bold;
-  textElem.style.fontSize = fontSize + 'px';
-  textElem.style.color = textColor;
-  textElem.textContent = text;
+    textElem.style.fontWeight = bold;
+    textElem.style.fontSize = fontSize + 'px';
+    textElem.style.color = textColor;
+    const isMobile = window.matchMedia('(max-width: 750px)').matches;
+    let offsetY = 0;
+    if (isMobile && font === 'MarshStencil') {
+      if (aspectRatio === '6') offsetY = 7;
+      else if (aspectRatio === '11') offsetY = 3;
+    }
+    textElem.style.transform = isMobile ? `translateY(${offsetY}px)` : 'none';
+    textElem.textContent = text;
 
   // Setze das Seitenverhältnis (wird auf Mobil und Desktop beachtet!)
   document.getElementById('outputBox').style.aspectRatio = `${aspectRatio} / 1`;

--- a/index_en.html
+++ b/index_en.html
@@ -139,9 +139,12 @@
         width: 100vw;
         max-width: 100vw;
         box-sizing: border-box;
-        padding: 10px 0 10px -10;
+        padding: 10px;
         border-radius: 0;
         box-shadow: none;
+      }
+      .form-group label {
+        flex: 0 0 100%;
       }
       #outputBox {
         min-width: 0;
@@ -253,10 +256,17 @@ function adjustFontSize() {
   }
 
   textElem.style.fontFamily = fontStack;
-  textElem.style.fontWeight = bold;
-  textElem.style.fontSize = fontSize + 'px';
-  textElem.style.color = textColor;
-  textElem.textContent = text;
+    textElem.style.fontWeight = bold;
+    textElem.style.fontSize = fontSize + 'px';
+    textElem.style.color = textColor;
+    const isMobile = window.matchMedia('(max-width: 750px)').matches;
+    let offsetY = 0;
+    if (isMobile && font === 'MarshStencil') {
+      if (aspectRatio === '6') offsetY = 7;
+      else if (aspectRatio === '11') offsetY = 3;
+    }
+    textElem.style.transform = isMobile ? `translateY(${offsetY}px)` : 'none';
+    textElem.textContent = text;
 
   // Set aspect ratio (respected on mobile and desktop)
   document.getElementById('outputBox').style.aspectRatio = `${aspectRatio} / 1`;


### PR DESCRIPTION
## Summary
- fix negative padding on mobile container
- ensure form-group labels take full width on small screens
- adjust Marsh font down 10px in mobile view
- apply per-length offset for Marsh font (7, 3, 0)

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68572a8e551c8330a3cfeb1b0f7a6fe4