### PR TITLE
Fix CDN inclusion for Marsh-Stencil font

### DIFF
--- a/index_de.html
+++ b/index_de.html
@@ -7,7 +7,7 @@
   <style>
     @font-face {
       font-family: 'MarshStencil';
-      src: url('Marsh-Stencil.woff') format('woff');
+      src: url('https://cdn.jsdelivr.net/gh/Nukl34r20m813/MarshStencil@main/Marsh-Stencil.woff') format('woff');
       font-weight: normal;
       font-style: normal;
       font-display: swap;

--- a/index_en.html
+++ b/index_en.html
@@ -7,7 +7,7 @@
   <style>
     @font-face {
       font-family: 'MarshStencil';
-      src: url('Marsh-Stencil.woff') format('woff');
+      src: url('https://cdn.jsdelivr.net/gh/Nukl34r20m813/MarshStencil@main/Marsh-Stencil.woff') format('woff');
       font-weight: normal;
       font-style: normal;
       font-display: swap;


### PR DESCRIPTION
## Summary
- reference `Marsh-Stencil.woff` through jsDelivr CDN just like the other fonts

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6857c34c6ce8833097e5f95244cb9a3c