### PR TITLE
Fix MarshStencil line height on mobile

### DIFF
--- a/index_de.html
+++ b/index_de.html
@@ -293,6 +293,12 @@ function adjustFontSize() {
     textElem.style.color = textColor;
     textElem.textContent = text;
 
+  if (font === 'MarshStencil' && window.innerWidth <= 750) {
+    textElem.style.lineHeight = '0.85';
+  } else {
+    textElem.style.lineHeight = '';
+  }
+
   // Setze oder berechne das Seitenverhältnis
   updateAspectRatio(aspectRatio);
 

--- a/index_en.html
+++ b/index_en.html
@@ -292,6 +292,12 @@ function adjustFontSize() {
     textElem.style.color = textColor;
     textElem.textContent = text;
 
+  if (font === 'MarshStencil' && window.innerWidth <= 750) {
+    textElem.style.lineHeight = '0.85';
+  } else {
+    textElem.style.lineHeight = '';
+  }
+
   // Set or calculate aspect ratio
   updateAspectRatio(aspectRatio);
 


### PR DESCRIPTION
## Summary
- compensate Marsh Stencil's large line gap on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857d5535a08833092e9c56b23c4a700